### PR TITLE
Use new `express-authentication-header` library.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
 - '0.11'

--- a/lib/basic.js
+++ b/lib/basic.js
@@ -2,50 +2,24 @@
 'use strict';
 
 var _ = require('lodash'),
-	authHeader = require('auth-header');
+	header = require('express-authentication-header');
 
 function parse(auth) {
 	var parts = new Buffer(auth.token, 'base64').toString('utf8').split(':', 2);
-	return _.assign(auth.params, {
+	return _.assign(auth, {
 		username: parts[0],
 		password: parts[1]
 	});
 }
 
-/**
- * Create HTTP Basic authentication middleware.
- * @param {Function} checkPassword Function to call to verify
- * @returns {Function} Middleware for authentication.
- */
-function basicAuthenticator(checkPassword) {
-
-	// Make sure checkPassword is a function
-	if (!_.isFunction(checkPassword)) {
-		throw new TypeError();
+module.exports = function create(options) {
+	if (_.isFunction(options)) {
+		options = {
+			verify: options
+		};
 	}
-
-	return function basicAuthentication(req, res, next) {
-
-		res.set('WWW-Authenticate', authHeader.format('Basic'));
-
-		var auth = authHeader.parse(req.get('authorization'));
-
-		var challenge = parse(auth);
-
-		req.challenge = challenge;
-
-		checkPassword(challenge, function done(err, status, result) {
-
-			if (err) {
-				return next(err);
-			}
-
-			req.authenticated = status;
-			req.authentication = result;
-
-			next();
-		});
-	};
-}
-
-module.exports = basicAuthenticator;
+	return header(_.assign({
+		scheme: 'Basic',
+		parse: parse
+	}, options));
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "express-authentication-basic",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "HTTP Basic compatible with express-authentication.",
 	"author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
 	"keywords": [ "express-authentication", "express", "basic", "auth" ],
@@ -18,7 +18,7 @@
 		"coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
 	},
 	"dependencies": {
-		"auth-header": "^0.1.0",
+		"express-authentication-header": "^0.1.1",
 		"lodash": "^2.4.1"
 	},
 	"devDependencies": {
@@ -28,8 +28,5 @@
 		"istanbul": "^0.3.2",
 		"chai": "^1.10.0",
 		"supertest": "^0.15.0"
-	},
-	"peerDependencies": {
-		"express-authentication": "^0.2.0"
 	}
 }


### PR DESCRIPTION
This greatly simplifies the amount of code required for this module. Still functions as before, cept with less code to manage.