### PR TITLE
Add support for static passwords.

### DIFF
--- a/lib/basic.js
+++ b/lib/basic.js
@@ -10,10 +10,29 @@ function parse(auth) {
 	});
 }
 
+function simple(username, password) {
+	return function check(challenge, callback) {
+		var valid =
+			(!username || challenge.username === username) &&
+			challenge.password === password;
+		callback(
+			null,
+			valid,
+			valid ? { user: challenge.username } : { }
+		);
+	};
+}
+
 module.exports = function create(options) {
 	if (_.isFunction(options)) {
 		options = {
 			verify: options
+		};
+	} else if (_.isString(options)) {
+		options = {
+			verify: arguments.length > 1 ?
+				simple(arguments[0], arguments[1]) :
+				simple(null, arguments[0])
 		};
 	}
 	return header(_.assign({

--- a/test/spec/basic.spec.js
+++ b/test/spec/basic.spec.js
@@ -64,6 +64,51 @@ describe('basic', function() {
 		request(this.app).get('/').auth('billy', 'yyy').end(done);
 	});
 
+	it('should handle good simple username/password combos', function(done) {
+		var auth = basic('bob', 'xxx');
+		var app = express();
+		app.use(auth);
+		app.use(function(req, res, next) {
+			expect(req.authenticated).to.equal(true);
+			next();
+		});
+		app.get('/', function hello(req, res, next) {
+			res.status(200).send('OK');
+			next();
+		});
+		request(app).get('/').auth('bob', 'xxx').expect(200).end(done);
+	});
+
+	it('should handle bad simple username/password combos', function(done) {
+		var auth = basic('bob', 'xxx');
+		var app = express();
+		app.use(auth);
+		app.use(function(req, res, next) {
+			expect(req.authenticated).to.equal(false);
+			next();
+		});
+		app.get('/', function hello(req, res, next) {
+			res.status(200).send('OK');
+			next();
+		});
+		request(app).get('/').auth('bob', 'yyy').expect(200).end(done);
+	});
+
+	it('should work with just simple passwords', function(done) {
+		var auth = basic('password');
+		var app = express();
+		app.use(auth);
+		app.use(function(req, res, next) {
+			expect(req.authenticated).to.equal(true);
+			next();
+		});
+		app.get('/', function hello(req, res, next) {
+			res.status(200).send('OK');
+			next();
+		});
+		request(app).get('/').auth('xxx', 'password').expect(200).end(done);
+	});
+
 	it('should set authentication correctly', function(done) {
 		this.app.use(function(req, res, next) {
 			expect(req.authentication).to.deep.equal({ message: 'hello' });


### PR DESCRIPTION
Sometimes for testing or simple site protection you just want a single password to work with. This provides that option to the constructor:

```javascript
var auth = basic('username', 'password');
```